### PR TITLE
Updating the guide with some fixes in both languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project is in an early stage, all the files here have been contributed by o
 **IF YOU AREN'T COMFORTABLE MODDING YOUR PHONE OR ITS PARTITION TABLE OR YOU ARE PARANOID OF BRICKING YOUR DEVICE CLICK AWAY NOW!!! YOU HAVE BEEN WARNED, YOU ARE ON YOUR OWN IF YOU BRICK YOUR DEVICE!!! AGAIN! YOU HAVE BEEN WARNED!!!**
 
 
-## Choose you language
+## Choose your language
 
 - [English](language/english.md)
 

--- a/guide/English/1-Partitions.md
+++ b/guide/English/1-Partitions.md
@@ -11,7 +11,7 @@ This steps are necesary to make the partitions where we are going to install Win
 - Don't run the same command twice
 - DON'T REBOOT YOUR DEVICE if you think you made a mistake, ask for help in the [Telegram chat](https://t.me/winong8x)
 
-#### Boot TWRP on the device
+#### Boot TWRP 3.6.0 on the device
 
 
 #### Unmount all partitions
@@ -19,7 +19,7 @@ Go to mount on TWRP and unmount all partitions
 
 ## Move parted to the device
 ```cmd
-adb push parted /sbin
+adb push parted /cache
 ```
 
 ## Start ADB shell
@@ -30,13 +30,13 @@ adb shell
 # Create partitions
 #### Give parted necessary permissions
 ```sh
-chmod +x /sbin/*
+chmod 755 /cache/parted
 ```
 
 
 ### Start parted
 ```sh
-parted /dev/block/sda
+./parted /dev/block/sda
 ```
 
 ### Delete the `grow` partition
@@ -46,11 +46,15 @@ parted /dev/block/sda
 rm 31
 ```
 
-### Delete the `userdata` partition 
+### Resize the `userdata` partition
 >To make sure that partition 30 is userdata you can use
 >  `print all`
 ```sh
-rm 30
+resizepart 30
+```
+>Replace XX with the amount of storage you want for Userdata, the rest will be for Windows
+```sh
+XXGB
 ```
 
 ### Create partitions
@@ -59,20 +63,16 @@ rm 30
 #### For all models:
 
 - Create the ESP partition (stores Windows bootloader data and EFI files)
+>We want this partition to have 500MB, replace XX with the "END" of userdata
 ```sh
-mkpart esp fat32 19.1GB 19.5GB
+mkpart esp fat32 XXGB XX.5GB
 ```
 
 - Create the main partition where Windows will be installed to
+> Replace XX with the "END" of ESP, this storage will be for windows
 ```sh
-mkpart win ntfs 19.5GB 75.5GB
+mkpart win ntfs XX.5GB 126GB
 ```
-
-- Create the Android data partition
-```sh
-mkpart userdata ext4 75.5GB 126GB
-```
-
 
 ### Make ESP partiton bootable so the EFI image can detect it
 ```sh

--- a/guide/English/1-Partitions.md
+++ b/guide/English/1-Partitions.md
@@ -74,11 +74,6 @@ mkpart esp fat32 XXGB XX.5GB
 mkpart win ntfs XX.5GB 126GB
 ```
 
-### Make ESP partiton bootable so the EFI image can detect it
-```sh
-set 30 esp on
-```
-
 ### Exit parted
 ```sh
 quit

--- a/guide/English/1-Partitions.md
+++ b/guide/English/1-Partitions.md
@@ -91,17 +91,6 @@ quit
 adb shell
 ```
 
-### Format partitions
-- Format the ESP partiton as FAT32
-```sh
-mkfs.fat -F32 -s1 /dev/block/by-name/esp
-```
-
-- Format the Windows partition as NTFS
-```sh
-mkfs.ntfs -f /dev/block/by-name/win
-```
-
 - Format Android data
 Go to Wipe menu and press Format Data, then type `yes`.
 

--- a/guide/English/1-Partitions.md
+++ b/guide/English/1-Partitions.md
@@ -86,11 +86,6 @@ quit
 
 ### Reboot to TWRP
 
-### Start ADB shell again
-```cmd
-adb shell
-```
-
 - Format Android data
 Go to Wipe menu and press Format Data, then type `yes`.
 

--- a/guide/English/2-Instalation.md
+++ b/guide/English/2-Instalation.md
@@ -13,53 +13,10 @@
   
 - Then exit EDL, so your PC will recognize the G8x as a disk
 
-## Assign letters to disks
-  
-
-#### Start the diskpart
-
-> Once the G8x is detected as a disk
-
-```cmd
-diskpart
-```
-
-
-### Assign letter `x` to Windows volume
-
-#### Select the phone's Windows volume
-> use `list volume` to find it, usually it's the one before the last one
-
-```diskpart
-select volume <number>
-```
-
-#### Assign the letter x
-```diskpart
-assign letter=x
-```
-
-### Assign `y` to esp volume
-
-#### Select phone esp volume
-> use `list volume` to find it, usually it's the last one
-
-```diskpart
-select volume <number>
-```
-
-#### Assign letter y
-
-```diskpart
-assign letter=y
-```
-
-### Exit Windows diskpart:
-```diskpart
-exit
-```
-
-  
+- If you have engineering abl_a you can instead go to fastboot and run
+  ```sh
+  fastboot boot LGG8XMassStorageBoot.img
+  ```
   
 
 ## Install
@@ -101,6 +58,45 @@ bcdboot X:\Windows /s Y: /f UEFI
 
 ```cmd
 bcdedit /store Y:\EFI\Microsoft\BOOT\BCD /set {default} testsigning on
+```
+
+
+# Now we go back to recovery 
+
+#### Boot TWRP
+
+
+#### Unmount all partitions
+Go to mount on TWRP and unmount all partitions
+
+## Move parted to the device
+```cmd
+adb push parted /cache
+```
+
+## Start ADB shell
+```cmd
+adb shell
+```
+
+#### Give parted necessary permissions
+```sh
+chmod 755 /cache/parted
+```
+
+
+### Start parted
+```sh
+./parted /dev/block/sda
+```
+### Make ESP partiton bootable so the EFI image can detect it
+```sh
+set 30 esp on
+```
+
+### Exit parted
+```sh
+quit
 ```
 
 

--- a/guide/English/2-Instalation.md
+++ b/guide/English/2-Instalation.md
@@ -72,7 +72,7 @@ bcdedit /store Y:\EFI\Microsoft\BOOT\BCD /set {default} testsigning on
 > where Y is esp partition
 
 
-# Now we go back to recovery 
+# Create ESP Flag 
 
 > if you don't do this you windows will throw an error and cannot boot!
 

--- a/guide/English/2-Instalation.md
+++ b/guide/English/2-Instalation.md
@@ -17,6 +17,13 @@
   ```sh
   fastboot boot LGG8XMassStorageBoot.img
   ```
+
+# Format Esp and Win
+
+> On windows explorer identify ESP, it should be called EFI and have about 500MB
+> right click and fast format it as Fat32
+> Same with Win, it shouldnt have a name but be about the amount of GB you chose
+> right click and fast format it as NTFS
   
 
 ## Install
@@ -25,6 +32,7 @@
 
 > `install.wim` is in the sources folder of the ISO,
 > you can get it after mounting or extracting the ISO
+> replace `X` with the letter of your Win partition
 
 ```cmd
 dism /apply-image /ImageFile:<path/to/install.wim> /index:1 /ApplyDir:X:\
@@ -35,10 +43,11 @@ dism /apply-image /ImageFile:<path/to/install.wim> /index:1 /ApplyDir:X:\
 
 > open a cmd as Administrator
 
-> replace `<mh2lmdriversfolder>` with the location of the drivers folder
+> on cmd go to location of the drivers folder where `driverupdater.exe` is located
+> replace `X` with the letter of your Win partition
 
 ```cmd
-driverupdater.exe -d <mh2lmdriversfolder>\definitions\Desktop\ARM64\Internal\mh2lm.txt -r <mh2lmdriversfolder> -p X:
+.\driverupdater.exe -d .\definitions\Desktop\ARM64\Internal\mh2lm.txt -r . -p X:\
 ```
 
   

--- a/guide/English/2-Instalation.md
+++ b/guide/English/2-Instalation.md
@@ -74,6 +74,8 @@ bcdedit /store Y:\EFI\Microsoft\BOOT\BCD /set {default} testsigning on
 
 # Now we go back to recovery 
 
+> if you don't do this you windows will throw an error and cannot boot!
+
 #### Boot TWRP
 
 

--- a/guide/English/2-Instalation.md
+++ b/guide/English/2-Instalation.md
@@ -32,11 +32,11 @@
 
 > `install.wim` is in the sources folder of the ISO,
 > you can get it after mounting or extracting the ISO
-> replace `X` with the letter of your win partition
 
 ```cmd
 dism /apply-image /ImageFile:<path/to/install.wim> /index:1 /ApplyDir:X:\
 ```
+> replace `X` with the letter of your win partition
 
 
 # Install the Drivers
@@ -44,33 +44,32 @@ dism /apply-image /ImageFile:<path/to/install.wim> /index:1 /ApplyDir:X:\
 > open a cmd as Administrator
 
 > on cmd go to location of the drivers folder where `driverupdater.exe` is located
-> replace `X` with the letter of your win partition
 
 ```cmd
 .\driverupdater.exe -d .\definitions\Desktop\ARM64\Internal\mh2lm.txt -r . -p X:\
 ```
+> replace `X` with the letter of your win partition
 
   
 
 # Create the Windows bootloader files
 
->where X is win partition and Y is esp partition
 
 ```cmd
 bcdboot X:\Windows /s Y: /f UEFI
 ```
-
+>where X is win partition and Y is esp partition
   
   
 
 # Allow unsigned drivers
 
 > if you don't do this you will get a BSOD
-> where Y is esp partition
 
 ```cmd
 bcdedit /store Y:\EFI\Microsoft\BOOT\BCD /set {default} testsigning on
 ```
+> where Y is esp partition
 
 
 # Now we go back to recovery 

--- a/guide/English/2-Instalation.md
+++ b/guide/English/2-Instalation.md
@@ -32,7 +32,7 @@
 
 > `install.wim` is in the sources folder of the ISO,
 > you can get it after mounting or extracting the ISO
-> replace `X` with the letter of your Win partition
+> replace `X` with the letter of your win partition
 
 ```cmd
 dism /apply-image /ImageFile:<path/to/install.wim> /index:1 /ApplyDir:X:\
@@ -44,7 +44,7 @@ dism /apply-image /ImageFile:<path/to/install.wim> /index:1 /ApplyDir:X:\
 > open a cmd as Administrator
 
 > on cmd go to location of the drivers folder where `driverupdater.exe` is located
-> replace `X` with the letter of your Win partition
+> replace `X` with the letter of your win partition
 
 ```cmd
 .\driverupdater.exe -d .\definitions\Desktop\ARM64\Internal\mh2lm.txt -r . -p X:\
@@ -53,6 +53,8 @@ dism /apply-image /ImageFile:<path/to/install.wim> /index:1 /ApplyDir:X:\
   
 
 # Create the Windows bootloader files
+
+>where X is win partition and Y is esp partition
 
 ```cmd
 bcdboot X:\Windows /s Y: /f UEFI
@@ -64,6 +66,7 @@ bcdboot X:\Windows /s Y: /f UEFI
 # Allow unsigned drivers
 
 > if you don't do this you will get a BSOD
+> where Y is esp partition
 
 ```cmd
 bcdedit /store Y:\EFI\Microsoft\BOOT\BCD /set {default} testsigning on

--- a/guide/English/Uninstall.md
+++ b/guide/English/Uninstall.md
@@ -3,6 +3,8 @@
 
 # Windows on Lg G8x
 
+- Go to EDL mode and restore your boot_a and boot_b backups
+
 #### Boot TWRP on the device
 
 #### Unmount all partitions
@@ -13,61 +15,58 @@ Go to mount on TWRP and unmount all partitions
 adb push parted /cache
 ```
 
-## Iniciar ADB shell
+## Start ADB shell
 ```cmd
 adb shell
 ```
 
-# Restaurar particiones
-#### Darle los permisos necesarios a la herramienta
+# Restore Partitions
+#### Give parted necessary permissions
 ```sh
-chmod +x /sbin/*
+chmod 755 /cache/parted
 ```
 
 
-### Iniciar parted
+### Start Parted
 ```sh
-parted /dev/block/sda
+./parted /dev/block/sda
 ```
 
-### Borrar la partición `userdata` 
->Para asegurarte de que la partición 32 es userdata puedes usar
+### Delete `win` Partition
+>To make sure that partition 32 is win you can use 
 >  `print all`
 ```sh
 rm 32
 ```
 
-### Borrar la partición `win` 
->Para asegurarte de que la partición 31 es win puedes usar
+### Delete `esp` Partition
+>To make sure that partition 31 is esp you can use
 >  `print all`
 ```sh
 rm 31
 ```
 
-### Borrar la partición `esp` 
->Para asegurarte de que la partición 30 es esp puedes usar
+
+### Resize `userdata` Partition
+>To make sure that partition 31 is Userdata you can use
 >  `print all`
 ```sh
-rm 30
+resizepart 30
+126GB
 ```
 
-### Creamos la partición de datos de Android
-```sh
-mkpart userdata ext4 19.1GB 126GB
-```
-
-### Salir de parted
+### Exit Parted
 ```sh
 quit
 ```
 
-### Reiniciar a TWRP
+### Reboot to TWRP
 
-- Formatea data
-Ve a Wipe en TWRP y presiona Format Data, 
-después escribe `yes`.
+- Format data
+Go to Wipe menu on TWRP and press Format Data, 
+then write `yes`.
 
-### Comprueba si android inicia
-Solo reinicia el teléfono y comprueba si Android inicia
+### Check if Android boots
+Reboot your device and check if android works
 
-## ¡Terminado!
+## ¡Done!

--- a/guide/English/Uninstall.md
+++ b/guide/English/Uninstall.md
@@ -1,16 +1,16 @@
  <img align="right" src="https://github.com/Icesito68/Port-Windows-11-Lg-G8x/blob/Lg-G8x/mh2lm.png" width="350" alt="Windows 11 Running On A Lg G8x">
 
 
-# Windows en el Lg G8x
+# Windows on Lg G8x
 
-#### Arranca en TWRP del dispositivo
+#### Boot TWRP on the device
 
-#### Desmonta todas las particiones
-Ve a mount en TWRP y desmonta todas las particiones
+#### Unmount all partitions
+Go to mount on TWRP and unmount all partitions
 
-## Pasar las herramientas necesarias:
+## Move parted to the device
 ```cmd
-adb push parted /sbin
+adb push parted /cache
 ```
 
 ## Iniciar ADB shell

--- a/guide/English/Uninstall.md
+++ b/guide/English/Uninstall.md
@@ -67,6 +67,6 @@ Go to Wipe menu on TWRP and press Format Data,
 then write `yes`.
 
 ### Check if Android boots
-Reboot your device and check if android works
+Reboot your device and check if Android boots
 
 ## ¡Done!

--- a/guide/Español/1-Particiones.md
+++ b/guide/Español/1-Particiones.md
@@ -20,7 +20,7 @@ Ve a mount en TWRP y desmonta todas las particiones
 
 ## Pasar las herramientas necesarias:
 ```cmd
-adb push parted /sbin
+adb push parted /cache
 ```
 
 ## Iniciar ADB shell
@@ -31,13 +31,13 @@ adb shell
 # Crear particiones
 #### Darle los permisos necesarios a la herramienta
 ```sh
-chmod +x /sbin/*
+chmod 775 /cache/parted
 ```
 
 
 ### Iniciar parted
 ```sh
-parted /dev/block/sda
+./parted /dev/block/sda
 ```
 
 ### Borrar la partición `grow` 
@@ -47,11 +47,15 @@ parted /dev/block/sda
 rm 31
 ```
 
-### Borrar la partición `userdata` 
->Para asegurarte de que la partición 30 es userdata puedes usar
+### Redimensionar la partición `userdata` 
+>Para asegurarte de que la partición 30 es Userdata puedes usar
 >  `print all`
 ```sh
-rm 30
+resizepart 30
+```
+>Reemplaza XX con la cantidad de almacenamiento que quieras para Userdata, el resto se usara ora Windows
+```sh
+XXGB
 ```
 
 ### Crear particiones
@@ -60,24 +64,15 @@ rm 30
 #### Para todos los modelos:
 
 - Crea la partición ESP (Aqui estará el bootloader de Windows y los archivos EFI)
+>Necesitamos que esta particion tenga 500MB, reemplaza XX con lo que diga "END" en Userdata
 ```sh
-mkpart esp fat32 19.1GB 19.5GB
+mkpart esp fat32 XXGB XX.5GB
 ```
 
 - Creamos la partición principal donde instalaremos Windows
+> Reemplazamos XX con lo que diga "END" en ESP
 ```sh
-mkpart win ntfs 19.5GB 75.5GB
-```
-
-- Creamos la partición de datos de Android
-```sh
-mkpart userdata ext4 75.5GB 126GB
-```
-
-
-### Hace a ESP la partición de arranque para que la imagen EFI pueda detectarla
-```sh
-set 30 esp on
+mkpart win ntfs XX.5GB 126GB
 ```
 
 ### Salir de parted
@@ -92,16 +87,6 @@ quit
 adb shell
 ```
 
-### Formatear las particiones
--  Formatea la partición ESP en FAT32
-```sh
-mkfs.fat -F32 -s1 /dev/block/by-name/esp
-```
-
--  Formatea la partición de Windows en NTFS
-```sh
-mkfs.ntfs -f /dev/block/by-name/win
-```
 
 - Formatea data
 Ve a Wipe en TWRP y presiona Format Data, 

--- a/guide/Español/1-Particiones.md
+++ b/guide/Español/1-Particiones.md
@@ -53,7 +53,7 @@ rm 31
 ```sh
 resizepart 30
 ```
->Reemplaza XX con la cantidad de almacenamiento que quieras para Userdata, el resto se usara ora Windows
+>Reemplaza XX con la cantidad de almacenamiento que quieras para Userdata, el resto se usara en Windows
 ```sh
 XXGB
 ```

--- a/guide/Español/2-Instalación.md
+++ b/guide/Español/2-Instalación.md
@@ -13,54 +13,17 @@
   
 - Después sal de EDL, así tu PC reconocerá al G8x como un disco
 
-## Asignar letras a los discos
-  
+- como alternative, si tienes abl_a de ingenieria puedes ejecutar en fastboot lo siguiente
+  ```sh
+  fastboot boot LGG8XMassStorageBoot.img
+  ```
 
-#### Arranca diskpart en Windows
+# Formatear esp y win
 
-> Una vez que el G8x sea detectado como un disco
-
-```cmd
-diskpart
-```
-
-
-### Asignar letra `x` al volumen de Windows
-
-#### Selecciona el volumen de Windows del Teléfono
-> usa `list volume` para encontrarlo, normalmente es el penúltimo
-
-```diskpart
-select volume <number>
-```
-
-#### Assign the letter x
-```diskpart
-assign letter=x
-```
-
-### Asinar `y` al volumen de esp 
-
-#### Selecciona el volumen de esp del teléfono
-> usa `list volume` para encontrarlo, normalmente es el último
-
-```diskpart
-select volume <number>
-```
-
-#### Asignar letra y
-
-```diskpart
-assign letter=y
-```
-
-### Salir de diskpart:
-```diskpart
-exit
-```
-
-  
-  
+> identifica esp en el explorador de Windows, podria llamarse EFI y tener alrededor de 500MB
+> dale click derecho y formato rapido en fat32
+> lo mismo con win, podria no tener nombre pero tendra alrededor de la cantidad de GB que le pusiste anteriormente
+> dale click derecho y formato rapido en ntfs
 
 ## Instalar
 
@@ -72,18 +35,19 @@ exit
 ```cmd
 dism /apply-image /ImageFile:<path/to/install.wim> /index:1 /ApplyDir:X:\
 ```
+> reemplaza `X` con la letra de tu particion win
 
 
 # Instalar los Drivers
 
 > abre un cmd como Administrador
 
-> reemplaza `<mh2lmdriversfolder>` por la localización de la carpeta de drivers
+> en cmd ve a la ruta de la carpeta drivers, donde `driverupdater.exe` se encuentra
 
 ```cmd
-driverupdater.exe -d <mh2lmdriversfolder>\definitions\Desktop\ARM64\Internal\mh2lm.txt -r <mh2lmdriversfolder> -p X:
+.\driverupdater.exe -d .\definitions\Desktop\ARM64\Internal\mh2lm.txt -r . -p X:\
 ```
-
+> replace `X` with the letter of your win partition
   
 
 # Crear los archivos del bootloader de Windows 
@@ -91,6 +55,7 @@ driverupdater.exe -d <mh2lmdriversfolder>\definitions\Desktop\ARM64\Internal\mh2
 ```cmd
 bcdboot X:\Windows /s Y: /f UEFI
 ```
+>reemplaza `X` con la letra particion win y `Y` con la letra de la particion esp
 
   
   
@@ -102,6 +67,50 @@ bcdboot X:\Windows /s Y: /f UEFI
 ```cmd
 bcdedit /store Y:\EFI\Microsoft\BOOT\BCD /set {default} testsigning on
 ```
+> reemplaza `Y` con la letra de la particion esp
+
+
+
+# Poner Flag ESP  
+
+> Si no haces esto, Windows no continuara con la instalacion!
+
+#### Arranque a TWRP
+
+
+#### Desmonta todas las particiones
+Ve a mount en TWRP y desmonta todas las particiones
+
+## Mueve Parted al dispositivo
+```cmd
+adb push parted /cache
+```
+
+## Inicia ADB shell
+```cmd
+adb shell
+```
+
+#### Dale los permisos necesarios a Parted
+```sh
+chmod 755 /cache/parted
+```
+
+
+### Inicia parted
+```sh
+./parted /dev/block/sda
+```
+### Vuelve la particion ESP booteable para que la imagen EFI pueda encontrarla
+```sh
+set 30 esp on
+```
+
+### Sal de parted
+```sh
+quit
+```
+
 
 
 

--- a/guide/Español/2-Instalación.md
+++ b/guide/Español/2-Instalación.md
@@ -21,8 +21,11 @@
 # Formatear esp y win
 
 > identifica esp en el explorador de Windows, podria llamarse EFI y tener alrededor de 500MB
+
 > dale click derecho y formato rapido en fat32
+
 > lo mismo con win, podria no tener nombre pero tendra alrededor de la cantidad de GB que le pusiste anteriormente
+
 > dale click derecho y formato rapido en ntfs
 
 ## Instalar

--- a/guide/Español/2-Instalación.md
+++ b/guide/Español/2-Instalación.md
@@ -74,7 +74,7 @@ bcdedit /store Y:\EFI\Microsoft\BOOT\BCD /set {default} testsigning on
 
 
 
-# Poner Flag ESP  
+# Crear Flag ESP  
 
 > Si no haces esto, Windows no continuara con la instalacion!
 

--- a/guide/Español/Desinstalar.md
+++ b/guide/Español/Desinstalar.md
@@ -3,6 +3,8 @@
 
 # Windows en el Lg G8x
 
+- Entra en el modo EDL y restaura el respaldo de tus particiones boot_a y boot_b
+
 #### Arranca en TWRP del dispositivo
 
 #### Desmonta todas las particiones
@@ -10,7 +12,7 @@ Ve a mount en TWRP y desmonta todas las particiones
 
 ## Pasar las herramientas necesarias:
 ```cmd
-adb push parted /sbin
+adb push parted /cache
 ```
 
 ## Iniciar ADB shell
@@ -21,39 +23,35 @@ adb shell
 # Restaurar particiones
 #### Darle los permisos necesarios a la herramienta
 ```sh
-chmod +x /sbin/*
+chmod 755 /cache/parted
 ```
 
 
 ### Iniciar parted
 ```sh
-parted /dev/block/sda
+./parted /dev/block/sda
 ```
 
-### Borrar la partición `userdata` 
->Para asegurarte de que la partición 32 es userdata puedes usar
+### Borrar la partición `win` 
+>Para asegurarte de que la partición 32 es win puedes usar
 >  `print all`
 ```sh
 rm 32
 ```
 
-### Borrar la partición `win` 
->Para asegurarte de que la partición 31 es win puedes usar
+### Borrar la partición `esp` 
+>Para asegurarte de que la partición 31 es esp puedes usar
 >  `print all`
 ```sh
 rm 31
 ```
 
-### Borrar la partición `esp` 
->Para asegurarte de que la partición 30 es esp puedes usar
+### Redimensionar particion `userdata`
+>Para asegurarte de que la partición 30 es userdata puedes usar
 >  `print all`
 ```sh
-rm 30
-```
-
-### Creamos la partición de datos de Android
-```sh
-mkpart userdata ext4 19.1GB 126GB
+resizepart 30
+126GB
 ```
 
 ### Salir de parted


### PR DESCRIPTION
I made some modifications to the guide in both english and spanish in an attempt to fix some issues and try to make it easier to understand.
the modifications mainly were:
Resize Userdata instead of removing it
Alternative to formatting with windows explorer since the previous one wont work in some roms
Leaving the setup of ESP flag as the last "Installation" step, this allows windows to mount and set a letter to the drive automatically, and not needing to use diskpart.
removal of the diskpart step since is no longer needed
qfil alternative when flashing Mass Storage, using Fastboot with no need to flash if using en abl (Fastboot Boot).
translated and updated the "Uninstall" step to english, now it tells you to restore the original boot_a and boot_b and resizing userdata instead of deleting it

Sorry for the messy commits, its my first time making a pull request and actually using github